### PR TITLE
Parse the ticket from the branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ if (argv._[0] == 'j' || argv._[0] == 'jira') {
 function goToJira() {
   getBranch()
     .then(branch => {
-      let url = `${jiraUrl}/browse/${branch}`
+      let url = `${jiraUrl}/browse/${parseJiraTicket(branch)}`
       open(url)
     })
 }
@@ -86,6 +86,12 @@ function getBranch() {
       resolve(stdout.trim())
     })
   })
+}
+
+function parseJiraTicket(branch) {
+  const result = /\w+-\d+/.exec(branch);
+  if (result == null) return branch;
+  return result[0];
 }
 
 function parseRemote(remote) {


### PR DESCRIPTION
I don't normally _just_ use the JIRA ticket as the branch name, you should probably be giving some context along with the ticket. But anyway, this adds a regex that will grab the first thing in the format `\w+-\d+` out of the branch name. I made this branch name weird so that I could test it, and it totally works.